### PR TITLE
karma config scaffold

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: node_js
+addons:  
+  firefox: latest
 node_js:
   - "6"
   - "5"
   - "4"
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 script:
   - npm test
   - npm pack

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ node_js:
   - "5"
   - "4"
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3
 script:
   - npm test
   - npm pack

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "6"
+  - "5"
+  - "4"
+script:
+  - npm test
+  - npm pack

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: node_js
-addons:  
-  firefox: latest
+addons:
+  firefox: "latest"
 node_js:
   - "6"
   - "5"
-  - "4"
 before_install:
+  - "export CHROME_BIN=chromium-browser"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - "sleep 3"
 script:
-  - npm test
   - npm pack

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ node_js:
   - "6"
   - "5"
   - "4"
-before_script:
+before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - sleep 3
+  - "sleep 3"
 script:
   - npm test
   - npm pack

--- a/karma.conf
+++ b/karma.conf
@@ -11,7 +11,8 @@ module.exports = function(config) {
       'karma-webpack',
       'karma-phantomjs-launcher',
       'karma-sourcemap-loader',
-      'karma-firefox-launcher'
+      'karma-firefox-launcher',
+      'karma-chrome-launcher'
     ],
     babelPreprocessor: {
       options: {
@@ -21,8 +22,9 @@ module.exports = function(config) {
 
     basePath: './',
     frameworks: [ 'jasmine' ],
-    browsers: ['PhantomJS','Firefox'],
+    browsers: ['PhantomJS','Firefox','ChromeSandbox'],
     files: [
+      'node_modules/babel-polyfill/dist/polyfill.js',
       'src/espina/client/**/*.test.js',
       'src/espina/shared/**/*.test.js',
     ],
@@ -49,7 +51,12 @@ module.exports = function(config) {
           chunks: false
       }
     },
-
+    customLaunchers: {  
+      ChromeSandbox: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
     preprocessors: {
       'src/espina/client/**/*.js': PREPROCESSORS,
       'src/espina/shared/**/*.js': PREPROCESSORS,

--- a/karma.conf
+++ b/karma.conf
@@ -1,0 +1,42 @@
+/* module require*/
+
+const webpack_config = require('./client/config/test/webpack'),
+    PREPROCESSORS = ['webpack', 'sourcemap']
+
+module.exports = function(config) {
+  config.set({
+    plugins: [
+      'karma-webpack',
+      'karma-jasmine',
+      'karma-phantomjs-launcher',
+      'karma-sourcemap-loader'
+    ],
+
+    basePath: './',
+    frameworks: [ 'jasmine' ],
+    browsers: ['PhantomJS'],
+    files: [
+      'node_modules/babel-polyfill/dist/polyfill.js',
+      'src/client/**/*.test.js',
+      'src/shared/**/*.test.js'
+    ],
+
+    preprocessors: {
+      'src/client/**/*.test.js': PREPROCESSORS,
+      'src/shared/**/*.test.js': PREPROCESSORS
+    },
+
+    webpack: webpack_config,
+
+    webpackMiddleware: {
+      noInfo: true
+    },
+
+    reporters: [ 'dots' ],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: process.env.WATCH,
+    singleRun: !process.env.WATCH
+  })
+};

--- a/karma.conf
+++ b/karma.conf
@@ -1,38 +1,62 @@
 /* module require*/
 
-const webpack_config = require('./client/config/test/webpack'),
-    PREPROCESSORS = ['webpack', 'sourcemap']
+//const webpack_config = require('./client/config/test/webpack'),
+const PREPROCESSORS = ['babel','webpack','sourcemap']
 
 module.exports = function(config) {
   config.set({
     plugins: [
-      'karma-webpack',
+      'karma-babel-preprocessor',
       'karma-jasmine',
+      'karma-webpack',
       'karma-phantomjs-launcher',
-      'karma-sourcemap-loader'
+      'karma-sourcemap-loader',
+      'karma-firefox-launcher'
     ],
+    babelPreprocessor: {
+      options: {
+        presets: ['es2015','react'],
+      }
+    },
 
     basePath: './',
     frameworks: [ 'jasmine' ],
-    browsers: ['PhantomJS'],
+    browsers: ['PhantomJS','Firefox'],
     files: [
-      'node_modules/babel-polyfill/dist/polyfill.js',
-      'src/client/**/*.test.js',
-      'src/shared/**/*.test.js'
+      'src/espina/client/**/*.test.js',
+      'src/espina/shared/**/*.test.js',
     ],
+    webpack: {
+        module: {
+          loaders: [
+            {
+              test: /(\.js|\.jsx)$/,
+              loader: 'babel'
+            }
+          ]
+        },
+        resolve: {
+          extensions: ['', '.js', '.jsx'],
+          alias: {
+            "espina/shared": __dirname + '/src/espina/shared',
+            "espina/client": __dirname + '/src/espina/client'
+          }
+        }
+    },
+    webpackMiddleware: {
+      noInfo: true,
+      stats: {
+          chunks: false
+      }
+    },
 
     preprocessors: {
-      'src/client/**/*.test.js': PREPROCESSORS,
-      'src/shared/**/*.test.js': PREPROCESSORS
+      'src/espina/client/**/*.js': PREPROCESSORS,
+      'src/espina/shared/**/*.js': PREPROCESSORS,
+      'src/espina/shared/**/*.component.jsx': PREPROCESSORS
+      
     },
-
-    webpack: webpack_config,
-
-    webpackMiddleware: {
-      noInfo: true
-    },
-
-    reporters: [ 'dots' ],
+    reporters: [ 'progress' ],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.2",
   "description": "Starter kit and generator for ES6 React Isomorphic webapp (React, Redux, Webpack, Universal-Webpack, Karma, Jasmine)",
   "scripts": {
-    "test": "BABEL_DISABLE_CACHE=1 babel-node test.js",
+    "test": "npm run test_client && npm run test_server",
+    "test_client": "BABEL_DISABLE_CACHE=1 NODE_ENV=test karma start",
+    "test_server": "BABEL_DISABLE_CACHE=1 NODE_ENV=test babel-node test.server.js",
     "build": "babel src/espina --out-dir . --ignore mock.js,test.js,test.html",
     "prepublish": "npm run build"
   },
@@ -71,7 +73,13 @@
     "gulp-rename": "^1.2.2",
     "gulp-template": "^4.0.0",
     "jasmine": "^2.5.2",
-    "jsdom": "^9.6.0",
+    "karma": "0.13.x",
+    "karma-jasmine": "0.3.x",
+    "karma-phantomjs-launcher": "1.0.x",
+    "karma-phantomjs-shim": "1.2.x",
+    "karma-sourcemap-loader": "0.3.x",
+    "karma-spec-reporter": "0.0.x",
+    "karma-webpack": "1.7.x",
     "react-addons-test-utils": "^15.3.2"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Starter kit and generator for ES6 React Isomorphic webapp (React, Redux, Webpack, Universal-Webpack, Karma, Jasmine)",
   "scripts": {
     "test": "npm run test_client && npm run test_server && npm run lint",
-    "test_client": "BABEL_DISABLE_CACHE=1 NODE_ENV=test karma start",
+    "test_client": "BABEL_DISABLE_CACHE=1 NODE_ENV=test karma start karma.conf --browsers Firefox --single-run",
     "test_server": "BABEL_DISABLE_CACHE=1 NODE_ENV=test babel-node test.server.js",
     "build": "babel src/espina --out-dir . --ignore mock.js,test.js,test.html",
-    "lint": "eslint --fix test.js src shell generator-tools",
+    "lint": "eslint --fix test.server.js src shell generator-tools",
     "prepublish": "npm test && npm run build"
   },
   "repository": {
@@ -77,17 +77,22 @@
   "devDependencies": {
     "app-module-path": "^2.0.0",
     "babel-cli": "^6.16.0",
+    "babel-loader": "^6.2.7",
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
     "jasmine": "^2.5.2",
+    "jsdom": "^9.8.3",
     "karma": "0.13.x",
+    "karma-babel-preprocessor": "^6.0.1",
+    "karma-firefox-launcher": "^1.0.0",
     "karma-jasmine": "0.3.x",
     "karma-phantomjs-launcher": "1.0.x",
     "karma-phantomjs-shim": "1.2.x",
     "karma-sourcemap-loader": "0.3.x",
     "karma-spec-reporter": "0.0.x",
-    "karma-webpack": "1.7.x",
-    "react-addons-test-utils": "^15.3.2"
+    "karma-webpack": "^1.8.0",
+    "react-addons-test-utils": "^15.3.2",
+    "webpack": "^1.13.3"
   },
   "bin": {
     "espina": "./shell/espina.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "espina",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Starter kit and generator for ES6 React Isomorphic webapp (React, Redux, Webpack, Universal-Webpack, Karma, Jasmine)",
   "scripts": {
     "test": "npm run test_client && npm run test_server && npm run lint",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "path-to-regexp": "^1.6.0",
     "query-string": "^4.2.3",
     "react": "15.3.x",
-    "react-dom": "15.3.x",
+    "react-dom": "15.4.x",
     "react-redux": "4.4.x",
     "redux": "^3.6.0",
     "redux-loop": "^2.2.2",
@@ -92,7 +92,7 @@
     "karma-sourcemap-loader": "0.3.x",
     "karma-spec-reporter": "0.0.x",
     "karma-webpack": "^1.8.0",
-    "react-addons-test-utils": "^15.3.2",
+    "react-addons-test-utils": "15.4.x",
     "webpack": "^1.13.3"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "1.0.6",
   "description": "Starter kit and generator for ES6 React Isomorphic webapp (React, Redux, Webpack, Universal-Webpack, Karma, Jasmine)",
   "scripts": {
-    "test": "BABEL_DISABLE_CACHE=1 babel-node test.js && eslint --fix test.js src shell generator-tools",
+    "test": "npm run test_client && npm run test_server && npm run lint",
+    "test_client": "BABEL_DISABLE_CACHE=1 NODE_ENV=test karma start",
+    "test_server": "BABEL_DISABLE_CACHE=1 NODE_ENV=test babel-node test.server.js",
     "build": "babel src/espina --out-dir . --ignore mock.js,test.js,test.html",
-    "lint": "eslint",
+    "lint": "eslint --fix test.js src shell generator-tools",
     "prepublish": "npm test && npm run build"
   },
   "repository": {
@@ -78,7 +80,13 @@
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
     "jasmine": "^2.5.2",
-    "jsdom": "^9.6.0",
+    "karma": "0.13.x",
+    "karma-jasmine": "0.3.x",
+    "karma-phantomjs-launcher": "1.0.x",
+    "karma-phantomjs-shim": "1.2.x",
+    "karma-sourcemap-loader": "0.3.x",
+    "karma-spec-reporter": "0.0.x",
+    "karma-webpack": "1.7.x",
     "react-addons-test-utils": "^15.3.2"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "espina",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Starter kit and generator for ES6 React Isomorphic webapp (React, Redux, Webpack, Universal-Webpack, Karma, Jasmine)",
   "scripts": {
     "test": "npm run test_client && npm run test_server && npm run lint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "espina",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Starter kit and generator for ES6 React Isomorphic webapp (React, Redux, Webpack, Universal-Webpack, Karma, Jasmine)",
   "scripts": {
     "test": "npm run test_client && npm run test_server && npm run lint",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Starter kit and generator for ES6 React Isomorphic webapp (React, Redux, Webpack, Universal-Webpack, Karma, Jasmine)",
   "scripts": {
     "test": "npm run test_client && npm run test_server && npm run lint",
-    "test_client": "BABEL_DISABLE_CACHE=1 NODE_ENV=test karma start karma.conf --browsers Firefox --single-run",
+    "test_client": "BABEL_DISABLE_CACHE=1 NODE_ENV=test karma start karma.conf",
     "test_server": "BABEL_DISABLE_CACHE=1 NODE_ENV=test babel-node test.server.js",
     "build": "babel src/espina --out-dir . --ignore mock.js,test.js,test.html",
     "lint": "eslint --fix test.server.js src shell generator-tools",
@@ -84,6 +84,7 @@
     "jsdom": "^9.8.3",
     "karma": "0.13.x",
     "karma-babel-preprocessor": "^6.0.1",
+    "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.0",
     "karma-jasmine": "0.3.x",
     "karma-phantomjs-launcher": "1.0.x",

--- a/src/espina/client/test/state_manager.test.js
+++ b/src/espina/client/test/state_manager.test.js
@@ -12,24 +12,25 @@ function mockClientStateManagerBehavior() {
       stateManager.initializeStore(MOCK_STORE, MOCK_REDUCER);
     });
     it('storage value', () => {
-      window.localStorage = MOCK_LOCALSTORAGE;
+      window.localStorage.setItem('token', MOCK_LOCALSTORAGE.token);
       expect(StateManager.storageValue('token')).toEqual('123456');
     });
     it('storage json', () => {
-      window.localStorage = MOCK_LOCALSTORAGE;
+      window.localStorage.setItem('mockdata', MOCK_LOCALSTORAGE.mockdata);
       expect(StateManager.storageParse('mockdata')).toEqual({ mockkey: 'mockvalue' });
     });
     it('try retrieve invalid key', () => {
-      window.localStorage = MOCK_LOCALSTORAGE;
-      window.sessionStorage = MOCK_LOCALSTORAGE;
+      window.sessionStorage.setItem('mockdata', MOCK_LOCALSTORAGE.mockdata);
+      window.sessionStorage.setItem('token', MOCK_LOCALSTORAGE.token);
       expect(StateManager.storageParse('mock')).toBe(null);
     });
     it('try without localStorage', () => {
-      window.sessionStorage = MOCK_LOCALSTORAGE;
+      window.sessionStorage.setItem('mockdata', MOCK_LOCALSTORAGE.mockdata);
       expect(StateManager.storageParse('mockdata')).toEqual({ mockkey: 'mockvalue' });
     });
     it('try retrieve invalid key without sessionStorage', () => {
-      window.localStorage = MOCK_LOCALSTORAGE;
+      window.localStorage.setItem('mockdata', MOCK_LOCALSTORAGE.mockdata);
+      window.localStorage.setItem('token', MOCK_LOCALSTORAGE.token);
       expect(StateManager.storageParse('mock')).toBe(null);
     });
   });

--- a/src/espina/shared/application_component.js
+++ b/src/espina/shared/application_component.js
@@ -42,7 +42,7 @@ class ApplicationComponent extends React.Component {
 ApplicationComponent.propTypes = {
   stateManager: React.PropTypes.instanceOf(StateManager).isRequired,
   router: React.PropTypes.instanceOf(Router).isRequired,
-  i18n: React.PropTypes.object.isRequired,
+  i18n: React.PropTypes.object,
   // only required in browser
   createHistory: React.PropTypes.func,
   rootComponent: React.PropTypes.func.isRequired,
@@ -52,7 +52,7 @@ ApplicationComponent.propTypes = {
 ApplicationComponent.childContextTypes = {
   stateManager: React.PropTypes.instanceOf(StateManager).isRequired,
   router: React.PropTypes.instanceOf(Router).isRequired,
-  i18n: React.PropTypes.object.isRequired,
+  i18n: React.PropTypes.object,
 };
 
 export default ApplicationComponent;

--- a/src/espina/shared/components/route/route_link.component.jsx
+++ b/src/espina/shared/components/route/route_link.component.jsx
@@ -41,7 +41,7 @@ class RouteLinkComponent extends SpikeComponent {
 }
 
 RouteLinkComponent.propTypes = {
-  action: React.PropTypes.object.isRequired,
+  action: React.PropTypes.func,
   className: React.PropTypes.object,
   route: React.PropTypes.string.isRequired,
   payload: React.PropTypes.object,

--- a/src/espina/shared/components/route/route_link.component.jsx
+++ b/src/espina/shared/components/route/route_link.component.jsx
@@ -41,7 +41,7 @@ class RouteLinkComponent extends SpikeComponent {
 }
 
 RouteLinkComponent.propTypes = {
-  action: React.PropTypes.func.isRequired,
+  action: React.PropTypes.object.isRequired,
   className: React.PropTypes.object,
   route: React.PropTypes.string.isRequired,
   payload: React.PropTypes.object,

--- a/src/espina/shared/components/route/route_link.test.js
+++ b/src/espina/shared/components/route/route_link.test.js
@@ -9,7 +9,7 @@ import ApplicationComponent from 'espina/shared/application_component';
 import i18n from 'espina/shared/test/mock/i18nFactory.mock';
 import { MOCK_ROUTES, MOCK_STORE, MOCK_PAYLOAD } from 'espina/shared/test/mock/config.mock';
 import { MOCK_REDUCER, MOCK_ACTION_OK } from 'espina/shared/test/mock/reducer.mock';
-import RouteLink from './route_link.component';
+import RouteLink from 'espina/shared/components/route/route_link.component';
 
 function mockRouteLinkComponentBehavior() {
   describe('RouteLink component', () => {

--- a/src/espina/shared/route.js
+++ b/src/espina/shared/route.js
@@ -21,6 +21,9 @@ export default class Route {
   get path() {
     return this.data.path;
   }
+  get useHash() {
+    return this.data.useHash;
+  }
 
   get component() {
     if (this.data.component && typeof this.data.component === 'string') {
@@ -69,7 +72,8 @@ export default class Route {
   parseParams(location) {
     const route = this;
     const params = {};
-    const tokens = route.getMatch(location.pathname);
+    const tokens = this.useHash ? route.getMatch(location.pathname + location.hash)
+      : route.getMatch(location.pathname);
     if (tokens && tokens.keys.length !== 0) {
       let i = 1;
       tokens.keys.forEach((e) => { params[e.name] = tokens.token[i]; i += 1; });
@@ -85,6 +89,13 @@ export default class Route {
     }
     const routePath = i18n.t(this.key);
     return `/${i18n.language}/${routePath}`;
+  }
+
+  generateHash(params) {
+    if (this.data.generateHash) {
+      return this.data.generateHash(params);
+    }
+    return '';
   }
 
 }

--- a/src/espina/shared/route.js
+++ b/src/espina/shared/route.js
@@ -23,7 +23,7 @@ export default class Route {
   }
 
   get component() {
-    if (this.data.component && typeof this.data.component === "string") {
+    if (this.data.component && typeof this.data.component === 'string') {
       return require(`../../../shared/components/layouts/${this.data.component}/${this.data.component}.component`);
     } else if (this.data.component) {
       return this.data.component;

--- a/src/espina/shared/router.js
+++ b/src/espina/shared/router.js
@@ -14,18 +14,20 @@ export default class BaseRouter {
     return this.routes.filter(route => route.name !== 'Missing');
   }
 
-  findRouteByPath(pathname) {
+  findRouteByPath(location) {
     const router = this;
-    return router.routes.find(route =>
-       route.matchesLocation(pathname)
-    );
+    return router.routes.find((route) => {
+      const path = route.useHash ? (location.pathname + location.hash) : location.pathname;
+      return route.matchesLocation(path);
+    });
   }
 
   parseLocation(newLocation) {
-    const route = this.findRouteByPath(newLocation.pathname);
+    const route = this.findRouteByPath(newLocation);
     const location = {
       pathname: newLocation.pathname,
       query: queryString.parse(newLocation.search),
+      hash: newLocation.hash,
     };
     location.routeName = route.name;
     location.params = route.parseParams(location);

--- a/test.server.js
+++ b/test.server.js
@@ -17,7 +17,6 @@ global.navigator = window.navigator;
 const DEFAULT_FILES = [
   'src/espina/server/**/*.test.js',
   'src/espina/shared/**/*.test.js',
-  'src/espina/client/**/*.test.js',
 ];
 
 function interpretFiles(ifiles) {


### PR DESCRIPTION
**Summary**
We want to run tests in two separate contexts (1) Node and (2) browser. Karma allows tests to run in different headless browsers, including Chrome, Safari, and Firefox.

Let's configure client and shared tests to run through Karma, and server and shared tests to run on pure Node (ie jasmine).